### PR TITLE
Ext tests 0.1.2

### DIFF
--- a/.idea/HiCT_Server.iml
+++ b/.idea/HiCT_Server.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Jinja2" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,16 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="3">
+            <item index="0" class="java.lang.String" itemvalue="cooler" />
+            <item index="1" class="java.lang.String" itemvalue="matplotlib" />
+            <item index="2" class="java.lang.String" itemvalue="pytest" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/HiCT_Server.iml" filepath="$PROJECT_DIR$/.idea/HiCT_Server.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/tux/Documents/hitree&quot;
+  }
+}</component>
+</project>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,29 +5,42 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "HiCT server from hict source",
+      "name": "[win-flask] HiCT server from hict source",
       "type": "python",
       "request": "launch",
       "module": "flask",
       "env": {
-        "PYTHONPATH": "$PYTHONPATH:../hict/",
+        "PYTHONPATH": "C:\\Users\\tux\\Documents\\HiCT\\HiCT_Library",
         "FLASK_APP": "hict_server/api_controller/dev_demo_server.py",
         "FLASK_ENV": "development"
       },
       "args": [
         "run",
-        "--no-debugger"
+        "--no-debugger",
+        "--verbose"
       ],
       "jinja": true,
       "justMyCode": false
     },
     {
-      "name": "HiCT Server from source",
+      "name": "[nix] HiCT Server from source",
       "type": "python",
       "request": "launch",
       "module": "hict_server",
       "env": {
           "PYTHONPATH": "/home/tux/HiCT/HiCT_library/"
+      },
+      "args": [
+          "--verbose"
+      ],
+      "justMyCode": true
+  },{
+      "name": "[win] HiCT Server from source",
+      "type": "python",
+      "request": "launch",
+      "module": "hict_server",
+      "env": {
+          "PYTHONPATH": "C:\\Users\\tux\\Documents\\HiCT\\HiCT_Library"
       },
       "args": [
           "--verbose"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,19 @@
       "jinja": true,
       "justMyCode": false
     },
+    {
+      "name": "HiCT Server from source",
+      "type": "python",
+      "request": "launch",
+      "module": "hict_server",
+      "env": {
+          "PYTHONPATH": "/home/tux/HiCT/HiCT_library/"
+      },
+      "args": [
+          "--verbose"
+      ],
+      "justMyCode": true
+  },
     /* {
       "name": "HiCT server from pip hict",
       "type": "python",

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -421,7 +421,7 @@ def get_tile():
     row: int = int(request.args.get("row"))
     col: int = int(request.args.get("col"))
     tile_size: int = int(request.args.get("tile_size"))
-    normalization_algo_int: int = int(request.args.get("normalization") if "normalization" in request.args.keys else NormalizationType.LOG2.value)
+    normalization_algo_int: int = int(request.args.get("normalization") if "normalization" in request.args.keys() else NormalizationType.LOG10.value)
     
     normalization_algo: NormalizationType = NormalizationType(normalization_algo_int)
 
@@ -440,14 +440,15 @@ def get_tile():
             x1,
             y1,
             QueryLengthUnit.PIXELS,
-            normalization=normalization_algo
+            normalization_algo=normalization_algo
         )
 
     padded_dense_rect: np.ndarray = np.zeros(
         (tile_size, tile_size), dtype=dense_rect.dtype)
     padded_dense_rect[0:dense_rect.shape[0],
                       0: dense_rect.shape[1]] = dense_rect
-    dense_rect: np.ndarray = np.log10(1 + padded_dense_rect)
+    dense_rect: np.ndarray = padded_dense_rect
+    # dense_rect: np.ndarray = np.log10(1 + padded_dense_rect)
     # dense_rect: np.ndarray = np.log10(1+dense_rect)
 
     colored_image: np.ndarray = colormap(dense_rect)

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -13,7 +13,7 @@ from flask import Flask, request, make_response, send_file, jsonify
 from flask_cors import CORS
 from hict.api.ContactMatrixFacet import ContactMatrixFacet
 from hict.core.chunked_file import ChunkedFile
-from hict.core.common import QueryLengthUnit, ContigDescriptor, ScaffoldDescriptor
+from hict.core.common import QueryLengthUnit, ContigDescriptor, ScaffoldDescriptor, NormalizationType
 from hict.core.contig_tree import ContigTree
 from hict.core.scaffold_holder import ScaffoldHolder
 from matplotlib import pyplot as plt
@@ -421,6 +421,9 @@ def get_tile():
     row: int = int(request.args.get("row"))
     col: int = int(request.args.get("col"))
     tile_size: int = int(request.args.get("tile_size"))
+    normalization_algo_int: int = int(request.args.get("normalization") if "normalization" in request.args.keys else NormalizationType.LOG2.value)
+    
+    normalization_algo: NormalizationType = NormalizationType(normalization_algo_int)
 
     resolution: int = sorted(chunked_file.resolutions)[-level]
     x0: int = row * tile_size
@@ -436,7 +439,8 @@ def get_tile():
             y0,
             x1,
             y1,
-            QueryLengthUnit.PIXELS
+            QueryLengthUnit.PIXELS,
+            normalization=normalization_algo
         )
 
     padded_dense_rect: np.ndarray = np.zeros(

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -1,10 +1,14 @@
 from argparse import ArgumentParser, Namespace
 import argparse
+from cmath import isclose
 from collections import namedtuple
+from filecmp import DEFAULT_IGNORES
 import io
 import os
 from pathlib import Path
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict, Tuple, Union
+from base64 import encodebytes
+from urllib import response
 
 import flask
 import numpy as np
@@ -13,7 +17,7 @@ from flask import Flask, request, make_response, send_file, jsonify
 from flask_cors import CORS
 from hict.api.ContactMatrixFacet import ContactMatrixFacet
 from hict.core.chunked_file import ChunkedFile
-from hict.core.common import QueryLengthUnit, ContigDescriptor, ScaffoldDescriptor, NormalizationType
+from hict.core.common import QueryLengthUnit, ContigDescriptor, ScaffoldDescriptor
 from hict.core.contig_tree import ContigTree
 from hict.core.scaffold_holder import ScaffoldHolder
 from matplotlib import pyplot as plt
@@ -37,14 +41,18 @@ data_path: Path = Path('./data')
 
 chunked_file_lock: rwlock.RWLockWrite = rwlock.RWLockWrite()
 
-currentNormalizationSettings: NormalizationSettings = NormalizationSettings(
+DEFAULT_NORMALIZATION_SETTINGS: NormalizationSettings = NormalizationSettings(
     -1.0, 1.0, -1.0, 1.0, True
 )
 
-currentContrastRange: ContrastRangeSettings = ContrastRangeSettings(
+DEFAULT_CONTRAST_RANGE: ContrastRangeSettings = ContrastRangeSettings(
     0.0,
-    255.0
+    1.0
 )
+
+
+currentNormalizationSettings: NormalizationSettings = DEFAULT_NORMALIZATION_SETTINGS
+currentContrastRange: ContrastRangeSettings = DEFAULT_CONTRAST_RANGE
 
 currentMinSignalValue: Dict[int, Union[np.float64, np.int64]] = dict()
 currentMaxSignalValue: Dict[int, Union[np.float64, np.int64]] = dict()
@@ -119,7 +127,7 @@ def generate_assembly_info(f: ChunkedFile) -> AssemblyInfo:
 
 @app.post("/open")
 def open_file():
-    global chunked_file, filename, fasta_filename
+    global chunked_file, filename, fasta_filename, currentTileVersion, currentNormalizationSettings, currentContrastRange
     req = request.get_json()
     filename = req["filename"]
     fasta_filename = req["fastaFilename"]
@@ -130,6 +138,10 @@ def open_file():
     if filename is None or filename == "":
         return "Wrong filename specified", 404
     # TODO: Fix this
+
+    currentTileVersion = 0
+    currentNormalizationSettings = DEFAULT_NORMALIZATION_SETTINGS
+    currentContrastRange = DEFAULT_CONTRAST_RANGE
     chunked_file = ContactMatrixFacet.get_file_descriptor(
         str(data_path.joinpath(filename).resolve().absolute()))
     # chunked_file = ContactMatrixFacet.get_file_descriptor(filename)
@@ -433,17 +445,17 @@ def get_resolutions():
 def get_current_signal_range():
     if chunked_file is None:
         return "File is not opened yet", 400
-    version: int = int(request.args.get("version"))
+    version: int = int(request.get_json()["tileVersion"])
 
     actual_version: int
     with versionLock.gen_rlock():
         actual_version = currentTileVersion
 
-    if version < currentTileVersion:
+    if version < actual_version:
         resp = make_response()
         resp.status_code = 204
         return resp
-    elif version > currentTileVersion:
+    elif version > actual_version:
         bumpVersion(version)
 
     with minMaxLock.gen_rlock():
@@ -475,19 +487,45 @@ def set_normalization():
     return response
 
 
-def get_raw_tile_processing_function(raw_tile: np.ndarray) -> np.ndarray:
+def normalize_tile(
+    raw_tile: np.ndarray,
+    weights: Optional[Tuple[np.ndarray, np.ndarray]]
+) -> np.ndarray:
     if currentNormalizationSettings.preLogEnabled():
-        raw_tile = np.log(raw_tile) / currentNormalizationSettings.preLogLnBase
+        raw_tile = np.log1p(raw_tile) / \
+            currentNormalizationSettings.preLogLnBase
     if currentNormalizationSettings.coolerBalanceEnabled():
-        # TODO
-        print("TODO")
+        assert weights is not None, "Requested cooler balancing but didn't provide the weights?"
+        raw_tile = ContactMatrixFacet.apply_cooler_balance_to_dense_matrix(
+            raw_tile,
+            weights[0],
+            weights[1],
+            inplace=True
+        )
     if currentNormalizationSettings.postLogEnabled():
-        raw_tile = np.log(raw_tile) / \
+        raw_tile = np.log1p(raw_tile) / \
             currentNormalizationSettings.postLogLnBase
     return raw_tile
 
 
-@ app.get("/get_tile")
+def contrast_tile(
+    raw_tile: np.ndarray
+) -> np.ndarray:
+    lower_bound, upper_bound = (
+        currentContrastRange.lowerSignalBound,
+        currentContrastRange.upperSignalBound,
+    )
+    range = upper_bound - lower_bound
+    if np.isclose(range, 0):
+        range = 1.0
+    raw_tile = raw_tile - currentContrastRange.lowerSignalBound
+    raw_tile[raw_tile < 0] = 0
+    raw_tile[raw_tile > range] = range
+    raw_tile = raw_tile / range
+    return raw_tile
+
+
+@app.get("/get_tile")
 def get_tile():
     if chunked_file is None:
         return "File is not opened yet", 400
@@ -496,22 +534,17 @@ def get_tile():
     row: int = int(request.args.get("row"))
     col: int = int(request.args.get("col"))
     tile_size: int = int(request.args.get("tile_size"))
-    normalization_algo_int: int = int(request.args.get(
-        "normalization") if "normalization" in request.args.keys() else NormalizationType.LINEAR.value)
-
-    normalization_algo: NormalizationType = NormalizationType(
-        normalization_algo_int)
     version: int = int(request.args.get("version"))
 
     actual_version: int
     with versionLock.gen_rlock():
         actual_version = currentTileVersion
 
-    if version < currentTileVersion:
+    if version < actual_version:
         resp = make_response("Late query: current tile version is newer")
         resp.status_code = 204
         return resp
-    elif version > currentTileVersion:
+    elif version > actual_version:
         bumpVersion(version)
 
     resolution: int = sorted(chunked_file.resolutions)[-level]
@@ -521,7 +554,7 @@ def get_tile():
     y1: int = (1 + col) * tile_size
 
     with chunked_file_lock.gen_wlock():
-        raw_dense_rect = ContactMatrixFacet.get_dense_submatrix(
+        raw_dense_rect, row_weights, col_weights = ContactMatrixFacet.get_dense_submatrix(
             chunked_file,
             resolution,
             x0,
@@ -529,19 +562,29 @@ def get_tile():
             x1,
             y1,
             QueryLengthUnit.PIXELS,
-            normalization_algo=normalization_algo
+            fetch_cooler_weights=currentNormalizationSettings.coolerBalanceEnabled()
         )
 
-    padded_dense_rect: np.ndarray = np.zeros(
-        (tile_size, tile_size), dtype=raw_dense_rect.dtype)
-    padded_dense_rect[0:raw_dense_rect.shape[0],
-                      0: raw_dense_rect.shape[1]] = raw_dense_rect
-    # dense_rect: np.ndarray = np.log10(1+np.log10(1+padded_dense_rect))
-    #dense_rect: np.ndarray = np.log10(1 + padded_dense_rect)
-    dense_rect: np.ndarray = padded_dense_rect
-    # dense_rect: np.ndarray = np.log10(1+dense_rect)
+    dense_rect: np.ndarray = normalize_tile(
+        raw_dense_rect, (row_weights, col_weights))
 
-    colored_image: np.ndarray = colormap(dense_rect)
+    if dense_rect.size > 0:
+        minValue = dense_rect.min()
+        maxValue = dense_rect.max()
+        with minMaxLock.gen_wlock():
+            if level not in currentMinSignalValue.keys() or currentMinSignalValue[level] > minValue:
+                currentMinSignalValue[level] = minValue
+            if level not in currentMaxSignalValue.keys() or currentMaxSignalValue[level] < maxValue:
+                currentMaxSignalValue[level] = maxValue
+
+    dense_rect = contrast_tile(dense_rect)
+
+    padded_dense_rect: np.ndarray = np.zeros(
+        (tile_size, tile_size), dtype=dense_rect.dtype)
+    padded_dense_rect[0:dense_rect.shape[0],
+                      0: dense_rect.shape[1]] = dense_rect
+
+    colored_image: np.ndarray = colormap(padded_dense_rect)
     image_matrix: np.ndarray = colored_image[:, :, : 3] * 255
     image_matrix = image_matrix.astype(transport_dtype)
 
@@ -550,8 +593,19 @@ def get_tile():
     buf = io.BytesIO()
     image.save(buf, format='PNG')
     buf.seek(0)
+    
+    ranges: Dict
+    with minMaxLock.gen_rlock():
+        ranges = {
+            "lowerBounds": currentMinSignalValue,
+            "upperBounds": currentMaxSignalValue
+        }
 
-    response = make_response(send_file(buf, mimetype="image/png"))
+    # response = make_response(send_file(buf, mimetype="image/png"))
+    response = make_response(jsonify({
+        "ranges": ranges,
+        "image": encodebytes(buf.getvalue()).decode('ascii') # encode as base64
+    }))
     response.headers['Access-Control-Allow-Origin'] = '*'
     response.status_code = 200
     return response

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -363,9 +363,10 @@ def save():
 
     with chunked_file_lock.gen_wlock() as cfl:
         chunked_file.save()
-
-    resp: dict = {'contig_info': get_contig_descriptors(
-        chunked_file), 'result': "OK, file saved"}
+        resp: dict = {
+            'assembly': AssemblyInfoDTO.fromEntity(generate_assembly_info(chunked_file)),
+            'result': "OK, file saved"
+        }
 
     response = make_response(jsonify(resp))
     response.headers['Access-Control-Allow-Origin'] = '*'

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -436,6 +436,22 @@ def get_fasta_for_assembly():
     response.status_code = 200
     return response
 
+@ app.post("/get_agp_for_assembly")
+def get_agp_for_assembly():
+    global chunked_file
+    if chunked_file is None or chunked_file.state != ChunkedFile.FileState.OPENED:
+        raise Exception("File is not opened?")
+
+    buf = io.BytesIO()
+    with chunked_file_lock.gen_wlock() as cfl:
+        chunked_file.get_agp_for_assembly(buf)
+    buf.seek(0)
+
+    response = make_response(send_file(buf, mimetype="text/plain"))
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.status_code = 200
+    return response
+
 
 @ app.get("/get_resolutions")
 def get_resolutions():

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -38,7 +38,7 @@ data_path: Path = Path('./data')
 chunked_file_lock: rwlock.RWLockWrite = rwlock.RWLockWrite()
 
 currentNormalizationSettings: NormalizationSettings = NormalizationSettings(
-    -1.0, -1.0, True
+    -1.0, 1.0, -1.0, 1.0, True
 )
 
 currentContrastRange: ContrastRangeSettings = ContrastRangeSettings(

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -612,7 +612,7 @@ def get_tile():
     response = make_response(jsonify({
         "ranges": ranges,
         # encode as base64
-        "image": encodebytes(buf.getvalue()).decode('ascii')
+        "image": "".join(("data:image/png;base64,", encodebytes(buf.getvalue()).decode('ascii')))
     }))
     response.headers['Access-Control-Allow-Origin'] = '*'
     response.status_code = 200

--- a/hict_server/api_controller/dev_demo_server.py
+++ b/hict_server/api_controller/dev_demo_server.py
@@ -432,7 +432,7 @@ def get_tile():
     y1: int = (1 + col) * tile_size
 
     with chunked_file_lock.gen_wlock():
-        dense_rect = ContactMatrixFacet.get_dense_submatrix(
+        raw_dense_rect = ContactMatrixFacet.get_dense_submatrix(
             chunked_file,
             resolution,
             x0,
@@ -444,11 +444,12 @@ def get_tile():
         )
 
     padded_dense_rect: np.ndarray = np.zeros(
-        (tile_size, tile_size), dtype=dense_rect.dtype)
-    padded_dense_rect[0:dense_rect.shape[0],
-                      0: dense_rect.shape[1]] = dense_rect
+        (tile_size, tile_size), dtype=raw_dense_rect.dtype)
+    padded_dense_rect[0:raw_dense_rect.shape[0],
+                      0: raw_dense_rect.shape[1]] = raw_dense_rect
+    # dense_rect: np.ndarray = np.log10(1+np.log10(1+padded_dense_rect))
+    #dense_rect: np.ndarray = np.log10(1 + padded_dense_rect)
     dense_rect: np.ndarray = padded_dense_rect
-    # dense_rect: np.ndarray = np.log10(1 + padded_dense_rect)
     # dense_rect: np.ndarray = np.log10(1+dense_rect)
 
     colored_image: np.ndarray = colormap(dense_rect)

--- a/hict_server/api_controller/dto/dto.py
+++ b/hict_server/api_controller/dto/dto.py
@@ -63,8 +63,8 @@ class ScaffoldDescriptorDTO:
             int(descriptor.scaffold_id),
             descriptor.scaffold_name,
             ScaffoldBordersDTO.fromEntity(descriptor.scaffold_borders),
-            descriptor.scaffold_direction.value,
-            descriptor.spacer_length
+            int(descriptor.scaffold_direction.value),
+            int(descriptor.spacer_length)
         )
 
 
@@ -246,11 +246,11 @@ class OpenFileResponseDTO:
     @staticmethod
     def fromEntity(response: OpenFileResponse) -> 'OpenFileResponseDTO':
         return OpenFileResponseDTO(
-            response.status,
+            str(response.status),
             str(response.dtype),
             [int(r) for r in response.resolutions],
             [float(pr) for pr in response.pixelResolutions],
-            response.tileSize,
+            int(response.tileSize),
             AssemblyInfoDTO.fromEntity(response.assemblyInfo),
             [int(sz) for sz in response.matrixSizesBins]
         )

--- a/hict_server/api_controller/dto/dto.py
+++ b/hict_server/api_controller/dto/dto.py
@@ -212,7 +212,6 @@ class GetFastaForSelectionRequestDTO:
         self.from_bp_y: int = int(request_json['fromBpY'])
         self.to_bp_x: int = int(request_json['toBpX'])
         self.to_bp_y: int = int(request_json['toBpY'])
-        
 
     def toEntity(self) -> GetFastaForSelectionRequest:
         return GetFastaForSelectionRequest(
@@ -254,4 +253,60 @@ class OpenFileResponseDTO:
             response.tileSize,
             AssemblyInfoDTO.fromEntity(response.assemblyInfo),
             [int(sz) for sz in response.matrixSizesBins]
+        )
+
+
+@dataclass
+class NormalizationSettings:
+    preLogBase: np.float64
+    preLogLnBase: np.float64
+    postLogBase: np.float64
+    postLogLnBase: np.float64
+    applyCoolerWeights: bool
+
+    def preLogEnabled(self) -> bool:
+        return self.preLogBase > np.int64(1.0)
+
+    def postLogEnabled(self) -> bool:
+        return self.postLogBase > np.int64(1.0)
+
+    def coolerBalanceEnabled(self) -> bool:
+        return self.applyCoolerWeights
+
+
+@dataclass
+class NormalizationSettingsDTO:
+    def __init__(self, request_json) -> None:
+        self.preLogBase = request_json['preLogBase']
+        self.postLogBase = request_json['postLogBase']
+        self.applyCoolerWeights = request_json['applyCoolerWeights']
+
+    def toEntity(self) -> NormalizationSettings:
+        return NormalizationSettings(
+            np.float64(self.preLogBase),
+            np.log(np.float64(self.preLogBase)) if np.float64(
+                self.preLogBase) > 1.0 else 1.0,
+            np.float64(self.postLogBase),
+            np.log(np.float64(self.postLogBase)) if np.float64(
+                self.postLogBase) > 1.0 else 1.0,
+            bool(self.applyCoolerWeights)
+        )
+
+
+@dataclass
+class ContrastRangeSettings:
+    lowerSignalBound: np.float64
+    upperSignalBound: np.float64
+
+
+@dataclass
+class ContrastRangeSettingsDTO:
+    def __init__(self, request_json) -> None:
+        self.lowerSignalBound = request_json['lowerSignalBound']
+        self.upperSignalBound = request_json['upperSignalBound']
+
+    def toEntity(self) -> ContrastRangeSettings:
+        return ContrastRangeSettings(
+            np.float64(self.lowerSignalBound),
+            np.float64(self.upperSignalBound)
         )

--- a/loadfromsource.ps1
+++ b/loadfromsource.ps1
@@ -1,5 +1,4 @@
-#!/bin/bash
-Set-Variable "HICT_DIR" "${PSScriptRoot}/../hict/"
+Set-Variable "HICT_DIR" "${PSScriptRoot}/../HiCT_Library/"
 $env:PYTHONPATH += ";${HICT_DIR}"
 echo "Setting HICT_DIR = ${HICT_DIR} and PYTHONPATH = ${env:PYTHONPATH}"
 python -m hict_server

--- a/loadfromsource.sh
+++ b/loadfromsource.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-HICT_DIR="$SCRIPT_DIR/../hict/"
+HICT_DIR="$SCRIPT_DIR/../HiCT_library/"
 export PYTHONPATH="$PYTHONPATH:$HICT_DIR"
+echo "Setting PYTHONPATH=$PYTHONPATH"
 python3 -m hict_server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-hict~=0.1.1rc1
 matplotlib==3.5.2
 flask~=2.1.3
 scikit-image~=0.19.3

--- a/start_dev.ps1
+++ b/start_dev.ps1
@@ -1,4 +1,3 @@
-#!/bin/bash
 Set-Variable "HICT_DIR" "${PSScriptRoot}/../hict/"
 # $env:PYTHONPATH += ";${HICT_DIR}"
 echo "Setting HICT_DIR = ${HICT_DIR} and PYTHONPATH = ${env:PYTHONPATH}"


### PR DESCRIPTION
# New features in this version:

- [x] Added support for different normalization types including Cooler-like weights
- [x] Added contrast range support for the tiles
- [x] Added support for AGP Export

# Technical changes:

- [x] Tile images are now stored inside JSON response encoded with base64 to transfer additional info with each tile
- [x] Small fixes

# Future plans:

- [ ] Add support for 1D-tracks
- [ ] Add support for multithreading
- [ ] Refactor server into modules and add router